### PR TITLE
for looping in a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ Want to automatically convert a few PDF files to EPS? Turns out there's various 
 
 ## Usage
 ```sh
-./pdf2eps example_file.pdf
+pdf2eps example_file.pdf
+```
+
+Or, to convert all the PDF files in a directory
+
+```sh
+pdf2eps .
 ```
 
 ## Requirements

--- a/pdf2eps
+++ b/pdf2eps
@@ -8,8 +8,7 @@ pdftops=true
 
 conversion (){
   # get file name without extension, full path
-  b="${1%%.*}"
-  b=`basename $b`
+  b=`basename -s .pdf $1`
 
   full=`grealpath $1`
   echo "Converting: $1 (Absolute path: $full)"
@@ -47,11 +46,11 @@ if [[ -f $1 ]]; then
   # if a single file
   conversion $1
 
-# elif [[ -d $1 ]]; then
-#   # else if a directory
-#   for i in `ls $1/*.pdf`; do
-#     conversion $i
-#   done
+elif [[ -d $1 ]]; then
+  # else if a directory
+  for i in `ls $1/*.pdf`; do
+    conversion $i
+  done
 
 else
   echo "Call: ./pdf2eps [PDF file]"


### PR DESCRIPTION
Firstly, thanks so much for sharing this code!!

Previously, when commenting out the lines for looping within a directory, the script would name every file without the basename (e.g., instead of `converted/myfile_gs.pdf` the name would be `converted/_gs.pdf`). This meant that files would overwrite each other. I've made a minor change to the [`basename`](https://linuxhint.com/read_filename_without_extension_bash/) call that I believe fixes this problem.